### PR TITLE
Fix bug where the 'jump to pinned message' button is made invisible in collapsible_sidebars_refresh.css

### DIFF
--- a/collapsible_sidebars_refresh.css
+++ b/collapsible_sidebars_refresh.css
@@ -29,7 +29,7 @@
     [class^=linkTop] > [class^=children], /* channel buttons */
     [class^=linkTop] > [class^=name], /* channel namnes */
     [class^=linkBottom], /* call status */
-    [class^=actionButtons], /* call buttons */
+    [class^=actionButtons]:not(:has(> [class^=jumpButton])), /* call buttons, excluding the jump to message button */
     [class^=voiceUser] > [class^=content] > [class^=container] /* call names */
     {
         /* hide stuff */
@@ -48,7 +48,7 @@
     [class^=sidebar]:hover [class^=linkTop] > [class^=children], /* channel buttons */
     [class^=sidebar]:hover [class^=linkTop] > [class^=name], /* channel namnes */
     [class^=sidebar]:hover [class^=linkBottom], /* call status */
-    [class^=sidebar]:hover [class^=actionButtons], /* call buttons */
+    [class^=actionButtons]:not(:has(> [class^=jumpButton])), /* call buttons, excluding the 'jump to message' button for pinned messages */
     [class^=sidebar]:hover [class^=voiceUser] > [class^=content] > [class^=container] /* call names */
     {
         /* revert stuff */

--- a/collapsible_sidebars_refresh.css
+++ b/collapsible_sidebars_refresh.css
@@ -29,7 +29,7 @@
     [class^=linkTop] > [class^=children], /* channel buttons */
     [class^=linkTop] > [class^=name], /* channel namnes */
     [class^=linkBottom], /* call status */
-    [class^=actionButtons]:not(:has(> [class^=jumpButton])), /* call buttons, excluding the jump to message button */
+    [class^=actionButtons]:not(:has(> [class^=jumpButton])), /* call buttons, excluding the 'jump to message' button for pinned messages */
     [class^=voiceUser] > [class^=content] > [class^=container] /* call names */
     {
         /* hide stuff */
@@ -48,7 +48,7 @@
     [class^=sidebar]:hover [class^=linkTop] > [class^=children], /* channel buttons */
     [class^=sidebar]:hover [class^=linkTop] > [class^=name], /* channel namnes */
     [class^=sidebar]:hover [class^=linkBottom], /* call status */
-    [class^=actionButtons]:not(:has(> [class^=jumpButton])), /* call buttons, excluding the 'jump to message' button for pinned messages */
+    [class^=sidebar]:hover [class^=actionButtons]:not(:has(> [class^=jumpButton])), /* call buttons, excluding the 'jump to message' button for pinned messages */
     [class^=sidebar]:hover [class^=voiceUser] > [class^=content] > [class^=container] /* call names */
     {
         /* revert stuff */


### PR DESCRIPTION
The classes for the call buttons and the 'jump to pinned message' buttons use the same class name, so I updated the CSS so it only selects that class if it doesn't contain the jump button inside it ☺️
![image](https://github.com/user-attachments/assets/ffdeac74-1fdf-4b96-9502-cb536b980b19)
